### PR TITLE
fix grep to not find audio nvidia devices

### DIFF
--- a/node-config-json.sh
+++ b/node-config-json.sh
@@ -8,7 +8,7 @@ echo "    CoresPerSocket: \"$CORESPERSOCKET\""
 echo "    ThreadsPerCore: \"$THREADSPERCORE\""
 COUNT="0"
 echo ""$HOSTNAME"_GPU_AFFINITY:"
-for i in `lspci | grep -i nvidia | awk '{print $1}' | cut -d : -f 1`
+for i in `lspci | grep -i nvidia | grep -v Audio | awk '{print $1}' | cut -d : -f 1`
         do
         CPUAFFINITY=`cat /sys/class/pci_bus/0000:$i/cpulistaffinity`
         echo "    GPU"$COUNT": \"$CPUAFFINITY\""

--- a/node-config.sh
+++ b/node-config.sh
@@ -5,7 +5,7 @@ CORESPERSOCKET=`lscpu | grep "Core(s) per socket:" | cut -d : -f 2 | awk '{print
 COUNT="0"
 echo "Add lines between --- to gres.conf:"
 echo "---"
-for i in `lspci | grep -i nvidia | awk '{print $1}' | cut -d : -f 1`
+for i in `lspci | grep -i nvidia | grep -v Audio | awk '{print $1}' | cut -d : -f 1`
         do
         CPUAFFINITY=`cat /sys/class/pci_bus/0000:$i/cpulistaffinity`
         echo "NodeName=$HOSTNAME Name=gpu File=/dev/nvidia"$COUNT" CPUs=$CPUAFFINITY"


### PR DESCRIPTION
The line where it uses grep to find NVIDIA devices also shows audio devices in some cases.  I added another grep to exclude these results.